### PR TITLE
Bump Scikit Learn Interface & Speed Improvement Using pypuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,24 @@ This Simulation is the implementation for the paper **A Machine Learning-based S
 
 ## Prerequisites
 * Since the code is parallelized for the data generation (CRPs generation), ensure Open-MPI is installed on your laptop from here (https://www.open-mpi.org). 
+* This project can be run using Anaconda or pip.
 
+### Using Anaconda
 * Install anaconda 3 for python packages on your laptop. Ensure to make it your main python interpreter by typing in the terminal (which python).
 
 * After installing Anaconda 3, install the following packages: 
 
 	- install mpi4py from ( https://anaconda.org/anaconda/mpi4py )
 	- install term color from ( https://anaconda.org/omnia/termcolor )
+	- install pypuf from ( https://pypi.org/project/pypuf/ )
 
 * Navigate (sikit-learn/neural_network) directory in anaconda3. For instance, in Mac OSX it is usually located in this path ```/anaconda3/lib/python3.6/site-packages/sklearn/neural_network/```, and then replace ```_multilayer_perceptron.py``` with the modified one in this repository. If it will ask for your permission so accept and replace.
 
+### Using Pip
+* Clone this repository
+* Inside the repository, create a virtual environment using `python3 -m venv venv`
+* Activate it `source venv/bin/activate`
+* Install term color and pypuf `python3 -m pip install "pypuf>=0.0.9" termcolor scikit-learn boto3 mpi4py`
 
 ## How to run 
 
@@ -30,6 +38,9 @@ This Simulation is the implementation for the paper **A Machine Learning-based S
 
 * You can also state your neural network model parameters from command line: for instance if you want 3 hidden layers and minibatch= 1000, use --layers 3 --minibatch 1000. You can define your custom argument from ( get_args()) method in the main.py.
 
+* The tests can be run using pytest (install it using `python3 -m pip install pytest`)
+
+```python3 -m pytest```
 
 ## How to cite 
 ```

--- a/generator/__init__.py
+++ b/generator/__init__.py
@@ -20,7 +20,7 @@ class PUFGenerator(object):
     def generate_challenges(self, num_challenges, rank):
         np.random.seed(random.randint(0, 2 ** 16) + rank)
         C = np.random.choice(np.array([0, 1], dtype=np.int8), size=(num_challenges, self.num_stages))
-        challenges = np.unique(C, axis=0)
+        challenges = np.unique(C, axis=0) if self.num_stages < 32 else C
 
         # challenges = [random.randint(0, 2 ** self.num_stages - 1) for _ in range(num_challenges)]
         #

--- a/main.py
+++ b/main.py
@@ -74,10 +74,7 @@ if __name__ == "__main__":
     output = None
     filename = None
 
-    if sys.platform != 'darwin':
-        path = '/home/ubuntu/Ahmad/data/'
-    else:
-        path = '/Users/Ahmad/Desktop/data/'
+    path = ''
 
     # Generate directories to hold results
     if rank is MASTER_CORE:

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -18,8 +18,6 @@ class XOR_PUF_MultilayerPerceptron(BaseEstimator, ClassifierMixin):
         self.num_streams = num_streams
         self.num_stages = num_stages
         self.batch_size = batch
-        self.weights = None
-        self.intercepts = None
         self.solver = solver
         self.n_layers = n_layers
 
@@ -54,8 +52,6 @@ class XOR_PUF_MultilayerPerceptron(BaseEstimator, ClassifierMixin):
                                        batch_size=self.batch_size,
                                        early_stopping=True,
                                        verbose=True,
-                                       weights=self.weights,
-                                       intercepts=self.intercepts
                                        )
         self.estimator.fit(C, r)
         return self


### PR DESCRIPTION
This PR has two parts:

1. The first part uses the current directory instead of a hard coded path and adjusts the interface to scikit-learn. Both are required to run this code on a new installation.
2. The second part updates the CRP generation in the repository to use pypuf instead of the delay-based simulation that is in this codebase. I included pytest test routines to show that the simulation result is identical.
I conditioned the test for duplicates in the random challenges on the number of stages, as for more than 32 stages the chance that we have duplicate challenges in any digestible-size challenge set is practically zero. 
The simulation speed is improved by several orders of magnitude, on my `Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz` it now takes less than 5 seconds to generate a million CRPs of an 64-bit 8-XOR Arbiter PUF. This could be further improved by modifying the simulation for XORArbiterPUFs to not simulate the chains separately.

Unfortunately, using the code from this PR, both including only the first part and including both parts, I cannot reproduce the results for 64-bit 4-XOR Arbiter PUFs from the paper running `python main.py --streams 4 --stages 64 --challenges 200000`. After about 5mins, it stops with accuracy 50%. I'm fairly confident that the simulation improvement isn't to blame, as the tests show that the simulation results didn't change. Maybe scikit-learn behavior changed since publication? I'm using scikit-learn 0.24.1 from pypi. Running older versions failed due to different reasons such as installation failure or incompatible API.

@kmursi